### PR TITLE
Fix a typo in lifestream post 796

### DIFF
--- a/content/lifestream/posts.yaml
+++ b/content/lifestream/posts.yaml
@@ -4020,7 +4020,7 @@
 - id: 796
   publishDate: "2021-02-21T18:21:19Z"
   post: >-
-    Just upgraded hyperbo.la's build pipeline to #webpack 4 #hypstatic
+    Just upgraded hyperbo.la's build pipeline to #webpack 5 #hypstatic
 - id: 797
   publishDate: "2021-02-21T18:21:19Z"
   post: >-


### PR DESCRIPTION
hyperbola was upgraded to webpack@5, not webpack@4.