### PR TITLE
Fix malformed markdown link in social-coding-2018 blog post

### DIFF
--- a/content/blog/social-coding-2018/post.md
+++ b/content/blog/social-coding-2018/post.md
@@ -53,8 +53,7 @@ should [depend on tokio sub crates]. [GH-10] reduces the number of crates that
 [futures]: https://docs.rs/futures/0.1.25/futures/
 [depend on tokio sub crates]:
   https://github.com/tokio-rs/tokio/tree/v0.1.x#project-layout
-
-[GH-10]: https://github.com/asomers/futures-locks/pull/10
+[gh-10]: https://github.com/asomers/futures-locks/pull/10
 
 ### Successes in 2018
 

--- a/content/blog/social-coding-2018/post.md
+++ b/content/blog/social-coding-2018/post.md
@@ -54,7 +54,7 @@ should [depend on tokio sub crates]. [GH-10] reduces the number of crates that
 [depend on tokio sub crates]:
   https://github.com/tokio-rs/tokio/tree/v0.1.x#project-layout
 
-[GH-10]: https://github.com/asomers/futures-locks/pull/10) reduces the number of
+[GH-10]: https://github.com/asomers/futures-locks/pull/10
 
 ### Successes in 2018
 


### PR DESCRIPTION
## Before

<img width="1480" alt="Screen Shot 2021-07-10 at 2 46 29 PM" src="https://user-images.githubusercontent.com/860434/125177049-a502e200-e18d-11eb-8e16-9d11e2c43bef.png">
