### PR TITLE
Upgrade hyperbola to Bootstrap 5

### DIFF
--- a/content/lifestream/posts.yaml
+++ b/content/lifestream/posts.yaml
@@ -4074,3 +4074,11 @@
     Yay! hyperbo.la is running Bootstrap v5. This upgrade was actually really
     small! Just some small changes to the Sass for customizing colors and
     updates to the navbar. #win
+- id: 806
+  publishDate: "2021-08-02T15:30:46Z"
+  post: >-
+    I got a PR in artichoke suggesting to bump down the frequency of dependabot
+    updates to monthly. I applied this change across all artichoke, hyperbola,
+    and lopopolo repositories. It has been a big quality of life improvement and
+    cuts down on a lot of churn in JS dependencies. Applying dep updates once a
+    month is 👍 #win #artichoke

--- a/content/lifestream/posts.yaml
+++ b/content/lifestream/posts.yaml
@@ -4068,3 +4068,9 @@
   post: >-
     Most crates are no-std when possible, 100% documented, and I think pretty
     high quality. #patch #rust
+- id: 805
+  publishDate: "2021-08-02T15:28:47Z"
+  post: >-
+    Yay! hyperbo.la is running Bootstrap v5. This upgrade was actually really
+    small! Just some small changes to the Sass for customizing colors and
+    updates to the navbar. #win

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,14 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "bootstrap": "^4.6.0",
+        "@popperjs/core": "^2.9.2",
+        "bootstrap": "^5.0.2",
         "commander": "^8.1.0",
         "ejs": "^3.1.6",
-        "jquery": "^3.6.0",
         "js-yaml": "^4.1.0",
         "linkifyjs": "^2.1.9",
         "luxon": "^2.0.1",
         "paginate-array": "^2.1.0",
-        "popper.js": "^1.16.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -67,6 +66,15 @@
       "peerDependencies": {
         "svgo": "^2.3.1",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@trysound/sax": {
@@ -432,16 +440,15 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.2.tgz",
+      "integrity": "sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.9.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1632,7 +1639,8 @@
     "node_modules/jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2101,16 +2109,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -3491,6 +3489,11 @@
       "dev": true,
       "requires": {}
     },
+    "@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+    },
     "@trysound/sax": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
@@ -3812,9 +3815,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.2.tgz",
+      "integrity": "sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==",
       "requires": {}
     },
     "brace-expansion": {
@@ -4685,7 +4688,8 @@
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5032,11 +5036,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
       "version": "8.3.6",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,14 @@
     "generate": "./bin/generate.js"
   },
   "dependencies": {
-    "bootstrap": "^4.6.0",
+    "@popperjs/core": "^2.9.2",
+    "bootstrap": "^5.0.2",
     "commander": "^8.1.0",
     "ejs": "^3.1.6",
-    "jquery": "^3.6.0",
     "js-yaml": "^4.1.0",
     "linkifyjs": "^2.1.9",
     "luxon": "^2.0.1",
     "paginate-array": "^2.1.0",
-    "popper.js": "^1.16.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,9 +1,4 @@
 $primary: rgb(40, 220, 220);
-$custom-colors: (
-  "primary": $primary,
-);
-
-$theme-colors: map-merge($theme-colors, $custom-colors);
 
 $hyperbola-bg-dark: #222;
 $hyperbola-bg-light: #444;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,7 +1,9 @@
 $primary: rgb(40, 220, 220);
-$theme-colors: (
+$custom-colors: (
   "primary": $primary,
 );
+
+$theme-colors: map-merge($theme-colors, $custom-colors);
 
 $hyperbola-bg-dark: #222;
 $hyperbola-bg-light: #444;

--- a/src/index.scss
+++ b/src/index.scss
@@ -2,6 +2,12 @@
 @import "bootstrap";
 @import "header";
 
+$custom-colors: (
+  "primary": $primary,
+);
+
+$theme-colors: map-merge($theme-colors, $custom-colors);
+
 .hyperbola-section-title {
   background-color: $hyperbola-bg-light;
   color: $primary;

--- a/src/index.scss
+++ b/src/index.scss
@@ -20,5 +20,5 @@
 }
 
 .hyperbola-text-timestamp {
-  color: lighten($text-muted, 20%);
+  color: tint-color($text-muted, 20%);
 }

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -1,43 +1,48 @@
 <nav class="navbar navbar-expand-md">
-  <a class="navbar-brand p-0" href="/" aria-label="hyperbola">
-    <img
-      class="float-left"
-      title="hyperbola"
-      alt="Hyperbola logo"
-      src="~@hyperbola/logo/optimized/wordmark.svg"
-    />
-    <span class="sr-only">hyperbola</span>
-  </a>
-  <button
-    class="navbar-toggler"
-    type="button"
-    data-toggle="collapse"
-    data-target="#navbarSupportedContent"
-    aria-controls="navbarSupportedContent"
-    aria-expanded="false"
-    aria-label="Toggle navigation"
-  >
-    <span class="navbar-toggler-icon"></span>
-  </button>
+  <div class="container d-flex flex-row justify-content-between">
+    <a class="navbar-brand p-0" href="/" aria-label="hyperbola">
+      <img
+        class="float-start"
+        height="80"
+        title="hyperbola"
+        alt="Hyperbola logo"
+        src="~@hyperbola/logo/optimized/wordmark.svg"
+      />
+      <span class="visually-hidden">hyperbola</span>
+    </a>
+    <button
+      class="navbar-toggler"
+      type="button"
+      data-bs-toggle="collapse"
+      data-bs-target="#navbarSupportedContent"
+      aria-controls="navbarSupportedContent"
+      aria-expanded="false"
+      aria-label="Toggle navigation"
+    >
+      <span class="navbar-toggler-icon"></span>
+    </button>
 
-  <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav ml-auto">
-      <div class="container d-flex flex-column flex-md-row justify-content-end">
-        <li class="nav-item">
-          <a class="nav-link nav-link-frontpage" href="/"> home </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link nav-link-contact" href="/contact/"> contact </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link nav-link-lifestream" href="/lifestream/">
-            lifestream
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link nav-link-blog" href="/w/"> blog </a>
-        </li>
-      </div>
-    </ul>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav ms-auto">
+        <div
+          class="container d-flex flex-column flex-md-row justify-content-end"
+        >
+          <li class="nav-item">
+            <a class="nav-link nav-link-frontpage" href="/"> home </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link nav-link-contact" href="/contact/"> contact </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link nav-link-lifestream" href="/lifestream/">
+              lifestream
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link nav-link-blog" href="/w/"> blog </a>
+          </li>
+        </div>
+      </ul>
+    </div>
   </div>
 </nav>


### PR DESCRIPTION
See https://github.com/hyperbola/hyperbola-static/pull/274.

This PR updates hyperbola-static to `bootstrap@5` and `@popperjs/core`. It removes dependencies on `popper.js` and `jquery`.

Updates were minimal (Bootstrap is great with back compat!):

- Update some Sass functions for renames and deprecations.
- Update declaration of primary color in theme map in custom Sass.
- Update navbar component.

This PR adds a couple of lifestream posts: one about the boostrap update and one about @dependabot changes.